### PR TITLE
Notes on federated learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Possible algorithms to support aggregated weights include:
 Proposed interface:
 
 ```sh
-tinymlkit <model-name> -m <federated_model.tmk> -m <federated_model.tmk> -m <federated_model.tmk> -m <federated_model.tmk> -f <model.tmk>
+tinymlkit <model-name> -r <federated_replay_buffer.txt> -r <federated_replay_buffer.txt> -r <federated_replay_buffer.txt> -f <model.tmk>
 ```
 
 Note that the `federated_model.tmk` file may contain summarised information about the underlying model. If `model.tmk` does not exist, it will be created through aggregation. 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ E.g. if our input `X` is `[1, 20, -3, 4]` and `y` is [2], then the input is:
 
 This naturally supports sparse formats where elements with the value 0 can be dropped.
 
+**Federated Learning**
+
+We will also explore Byzantine resilience for federated residual learning learning. At each step, the downstream clients will provide the "latest" model weights and labels to the server. It is then up the server to determine how to combine these candidate weights.
+
+There are many algorithms that offer Byzantine resilience guarentees under gradient descent, including: 
+
+- Coordinate-Wide Median
+- Geometric Mean
+- Mean around median
+
+We will have to verify them theoretically in the scenario we are updating weights via Nelder-Mead.  
+
 ## Roadmap
 
 1. Initial release targetting Go (with one algorithm?)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To keep things simple, we will target CLI only. The interface would resemble:
 
 ```sh
 # training
-tinymlkit <model-name> -d <data.txt> -f <model.tmk>
+tinymlkit <model-name> -d <data.txt> -r <replay_buffer.txt> -f <model.tmk>
 # prediction
 tinymlkit <model-name> -d <data.txt> -i <model.tmk> -p <output.txt>
 ``` 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,22 @@ This naturally supports sparse formats where elements with the value 0 can be dr
 
 **Federated Learning**
 
-We will also explore Byzantine resilience for federated residual learning learning. At each step, the downstream clients will provide the "latest" model weights and labels to the server. It is then up the server to determine how to combine these candidate weights.
+As we are using Nelder-Mead method for choosing the weights, and keeping a history of the set weights, we can offer Byzantine resilience when performing federated learning. 
 
-There are many algorithms that offer Byzantine resilience guarentees under gradient descent, including: 
+Possible algorithms to support aggregated weights include:
 
 - Coordinate-Wide Median
 - Geometric Mean
 - Mean around median
 
-We will have to verify them theoretically in the scenario we are updating weights via Nelder-Mead.  
+Proposed interface:
+
+```sh
+tinymlkit <model-name> -m <federated_model.tmk> -m <federated_model.tmk> -m <federated_model.tmk> -m <federated_model.tmk> -f <model.tmk>
+```
+
+Note that the `federated_model.tmk` file may contain summarised information about the underlying model. If `model.tmk` does not exist, it will be created through aggregation. 
+
 
 ## Roadmap
 


### PR DESCRIPTION
**Federated Learning**

It will be naturally have Byzantine Resilience due to the nature of Nelder-Mead algorithm. 

For updating weights:
- If it is a new model, then the federated weights become the initial points for Nelder-Mead algorithm to kick in
- If there is an existing model, then the federated weights are used as the initial centroid (perhaps mean around median) to assist with choosing the next point. We can also evaluate the centroid earlier to determine whether it is a suitable candidate point. (The centroids can be calculated using coordinate-wide mean)

For updating quantile sketches (P2) that is used for Hoeffding Inequalities
- Taking median for the markers and then combine.
- For the metrics, treat it as the median and number of observations seen to be $\frac{n}{2}$ or $\alpha \times n$ where $\alpha$ is the learning rate(?) can also be used.

This is geared towards linear and tree models. 

For boosting/bagging, there is the Poisson lambda approximation we can use (citation for later) - we probably should use a Gentle AdaBoost variant that is easier to implement and reason with (and robust due to it being non-greedy) 